### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Indeed, they are! The source code for each block is on NPM, but the JS/CSS is se
 
 **Can I add private custom blocks?**
 
-Sure! Just add your custom blocks into **wp-content/uploads/gutenberg-blocks/** folder. All your private blocks will be listed under `Local` tab in block explorer which you can activate/deactivate them. [This is what the folder structure should look like](https://github.com/front/cloud-blocks/blob/master/docs/private-blocks.md)!
+Sure! Just add your custom blocks into **wp-content/uploads/gutenberg-blocks/** folder. All your private blocks will be listed under `Local` tab in block explorer which you can activate/deactivate them. In order for your block to be active in the Gutenberg panel, it should be installed in Gutenberg Cloud. [This is what the folder structure should look like](https://github.com/front/cloud-blocks/blob/master/docs/private-blocks.md)!
 
 
 ## Changelog

--- a/core/Blocks/Explore.php
+++ b/core/Blocks/Explore.php
@@ -164,7 +164,7 @@ class Explore {
     foreach ($installed_blocks as $block) {
       // We must check if block is not local block, then we check for new versino availability
       $manifest = json_decode( stripslashes( $block->block_manifest ), true );
-      if ( !$manifest['isLocal'] ) {
+      if ( empty($manifest['isLocal']) ) {
         $args = array(
           'method' => 'GET'
         );

--- a/docs/private-blocks.md
+++ b/docs/private-blocks.md
@@ -1,6 +1,6 @@
 ### How can I add private custom blocks?
 
-Just add your custom blocks into **wp-content/uploads/gutenberg-blocks/** folder.
+Just add your custom blocks into **wp-content/uploads/gutenberg-blocks/** folder and install in Gutenberg Cloud.
 
 File structure must look like following:
 


### PR DESCRIPTION
1. Fixed a warning:
Undefined index: isLocal in /wp-content/plugins/cloud-blocks/core/Blocks/Explore.php on line 167

2. And extended private blocks info:
Just add your custom blocks into **wp-content/uploads/gutenberg-blocks/** folder **and install in Gutenberg Cloud.**
